### PR TITLE
Add refresh token support and endpoint in authentication module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>com.krisnaajiep</groupId>
     <artifactId>expense-tracker-api</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0-SNAPSHOT</version>
     <name>expense-tracker-api</name>
     <description>expense-tracker-api</description>
     <url/>
@@ -100,6 +100,12 @@
             <groupId>io.github.cdimascio</groupId>
             <artifactId>java-dotenv</artifactId>
             <version>5.2.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.16.0</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/krisnaajiep/expensetrackerapi/config/SecurityConfig.java
+++ b/src/main/java/com/krisnaajiep/expensetrackerapi/config/SecurityConfig.java
@@ -74,7 +74,7 @@ public class SecurityConfig {
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // Use stateless sessions
                 .httpBasic(AbstractHttpConfigurer::disable) // Disable basic authentication
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/register", "/login").permitAll() // Allow access to the test endpoint
+                        .requestMatchers("/register", "/login", "/refresh").permitAll() // Allow access to the test endpoint
                         .anyRequest().authenticated()) // Require authentication for all other requests
                 .addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .exceptionHandling(exception -> exception

--- a/src/main/java/com/krisnaajiep/expensetrackerapi/controller/AuthController.java
+++ b/src/main/java/com/krisnaajiep/expensetrackerapi/controller/AuthController.java
@@ -11,6 +11,7 @@ Version 1.0
 */
 
 import com.krisnaajiep.expensetrackerapi.dto.request.LoginRequestDto;
+import com.krisnaajiep.expensetrackerapi.dto.request.RefreshTokenRequestDto;
 import com.krisnaajiep.expensetrackerapi.dto.request.RegisterRequestDto;
 import com.krisnaajiep.expensetrackerapi.dto.response.TokenResponseDto;
 import com.krisnaajiep.expensetrackerapi.mapper.UserMapper;
@@ -50,6 +51,18 @@ public class AuthController {
         TokenResponseDto tokenResponseDto = authService.login(
                 loginRequestDto.getEmail(),
                 loginRequestDto.getPassword()
+        );
+        return ResponseEntity.status(HttpStatus.OK).body(tokenResponseDto);
+    }
+
+    @PostMapping(
+            value = "/refresh",
+            consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public ResponseEntity<TokenResponseDto> refresh(@Valid @RequestBody RefreshTokenRequestDto refreshTokenRequestDto) {
+        TokenResponseDto tokenResponseDto = authService.refreshToken(
+                refreshTokenRequestDto.getRefreshToken()
         );
         return ResponseEntity.status(HttpStatus.OK).body(tokenResponseDto);
     }

--- a/src/main/java/com/krisnaajiep/expensetrackerapi/dto/request/RefreshTokenRequestDto.java
+++ b/src/main/java/com/krisnaajiep/expensetrackerapi/dto/request/RefreshTokenRequestDto.java
@@ -1,0 +1,22 @@
+package com.krisnaajiep.expensetrackerapi.dto.request;
+
+/*
+IntelliJ IDEA 2025.1 (Ultimate Edition)
+Build #IU-251.23774.435, built on April 14, 2025
+@Author krisna a.k.a. Krisna Ajie
+Java Developer
+Created on 06/07/25 10.09
+@Last Modified 06/07/25 10.09
+Version 1.0
+*/
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class RefreshTokenRequestDto {
+    @NotBlank
+    @JsonProperty("refresh-token")
+    private String refreshToken;
+}

--- a/src/main/java/com/krisnaajiep/expensetrackerapi/dto/response/TokenResponseDto.java
+++ b/src/main/java/com/krisnaajiep/expensetrackerapi/dto/response/TokenResponseDto.java
@@ -19,4 +19,13 @@ import lombok.Getter;
 public class TokenResponseDto {
     @JsonProperty("access-token")
     private String accessToken;
+
+    @JsonProperty("refresh-token")
+    private String refreshToken;
+
+//    @JsonProperty("token-type")
+//    private String tokenType;
+//
+//    @JsonProperty("expires-in")
+//    private Long expiresIn;
 }

--- a/src/main/java/com/krisnaajiep/expensetrackerapi/handler/exception/UnauthorizedException.java
+++ b/src/main/java/com/krisnaajiep/expensetrackerapi/handler/exception/UnauthorizedException.java
@@ -1,0 +1,7 @@
+package com.krisnaajiep.expensetrackerapi.handler.exception;
+
+public class UnauthorizedException extends RuntimeException {
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/krisnaajiep/expensetrackerapi/model/RefreshToken.java
+++ b/src/main/java/com/krisnaajiep/expensetrackerapi/model/RefreshToken.java
@@ -1,0 +1,39 @@
+package com.krisnaajiep.expensetrackerapi.model;
+
+/*
+IntelliJ IDEA 2025.1 (Ultimate Edition)
+Build #IU-251.23774.435, built on April 14, 2025
+@Author krisna a.k.a. Krisna Ajie
+Java Developer
+Created on 05/07/25 11.11
+@Last Modified 05/07/25 11.11
+Version 1.0
+*/
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Instant;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity
+@EqualsAndHashCode(callSuper = true)
+public class RefreshToken extends Auditable {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "ID")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "UserID", nullable = false)
+    private User user;
+
+    @Column(name = "Token", nullable = false, unique = true)
+    private String token;
+
+    @Column(name = "ExpiryDate", nullable = false)
+    private Instant expiryDate;
+}

--- a/src/main/java/com/krisnaajiep/expensetrackerapi/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/krisnaajiep/expensetrackerapi/repository/RefreshTokenRepository.java
@@ -1,0 +1,21 @@
+package com.krisnaajiep.expensetrackerapi.repository;
+
+/*
+IntelliJ IDEA 2025.1 (Ultimate Edition)
+Build #IU-251.23774.435, built on April 14, 2025
+@Author krisna a.k.a. Krisna Ajie
+Java Developer
+Created on 06/07/25 09.27
+@Last Modified 06/07/25 09.27
+Version 1.0
+*/
+
+import com.krisnaajiep.expensetrackerapi.model.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByToken(String token);
+    void deleteAllByUserId(Long userId);
+}

--- a/src/main/java/com/krisnaajiep/expensetrackerapi/util/ValidationUtility.java
+++ b/src/main/java/com/krisnaajiep/expensetrackerapi/util/ValidationUtility.java
@@ -1,0 +1,35 @@
+package com.krisnaajiep.expensetrackerapi.util;
+
+/*
+IntelliJ IDEA 2025.1 (Ultimate Edition)
+Build #IU-251.23774.435, built on April 14, 2025
+@Author krisna a.k.a. Krisna Ajie
+Java Developer
+Created on 06/07/25 15.26
+@Last Modified 06/07/25 15.26
+Version 1.0
+*/
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.validation.FieldError;
+
+import java.lang.reflect.Field;
+
+public class ValidationUtility {
+    private static final Logger log = LoggerFactory.getLogger(ValidationUtility.class);
+
+    public static String getJsonPropertyName(FieldError error, Class<?> dtoClass) {
+        try {
+            Field field = dtoClass.getDeclaredField(error.getField());
+            JsonProperty jsonProperty = field.getAnnotation(JsonProperty.class);
+            return (jsonProperty != null && !jsonProperty.value().isBlank())
+                    ? jsonProperty.value()
+                    : error.getField();
+        } catch (Exception e) {
+            log.error("Error while getting json property name: {}", error.getField(), e);
+            return error.getField();
+        }
+    }
+}

--- a/src/test/java/com/krisnaajiep/expensetrackerapi/controller/AuthControllerTest.java
+++ b/src/test/java/com/krisnaajiep/expensetrackerapi/controller/AuthControllerTest.java
@@ -3,13 +3,17 @@ package com.krisnaajiep.expensetrackerapi.controller;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.krisnaajiep.expensetrackerapi.dto.request.LoginRequestDto;
+import com.krisnaajiep.expensetrackerapi.dto.request.RefreshTokenRequestDto;
 import com.krisnaajiep.expensetrackerapi.dto.request.RegisterRequestDto;
 import com.krisnaajiep.expensetrackerapi.dto.response.TokenResponseDto;
+import com.krisnaajiep.expensetrackerapi.model.RefreshToken;
 import com.krisnaajiep.expensetrackerapi.model.User;
 import com.krisnaajiep.expensetrackerapi.repository.ExpenseRepository;
+import com.krisnaajiep.expensetrackerapi.repository.RefreshTokenRepository;
 import com.krisnaajiep.expensetrackerapi.repository.UserRepository;
 import com.krisnaajiep.expensetrackerapi.security.JwtUtility;
 import com.krisnaajiep.expensetrackerapi.util.SecureRandomUtility;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,6 +25,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.Instant;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -33,6 +38,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class AuthControllerTest {
     @Autowired
     private UserRepository userRepository;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
 
     @Autowired
     private ExpenseRepository expenseRepository;
@@ -51,6 +59,7 @@ class AuthControllerTest {
 
     private final RegisterRequestDto registerRequestDto = new RegisterRequestDto();
     private final LoginRequestDto loginRequestDto = new LoginRequestDto();
+    private final RefreshTokenRequestDto refreshTokenRequestDto = new RefreshTokenRequestDto();
 
     private static final String USER_NAME = "John Doe";
     private static final String USER_EMAIL = "john@doe.com";
@@ -60,6 +69,7 @@ class AuthControllerTest {
     void setUp() {
         // Clean up the database before each test
         expenseRepository.deleteAll();
+        refreshTokenRepository.deleteAll();
         userRepository.deleteAll();
 
         passwordEncoder = new BCryptPasswordEncoder();
@@ -166,6 +176,10 @@ class AuthControllerTest {
             System.out.printf("Email from token: %s%n", email);
 
             assertEquals(registerRequestDto.getEmail(), email);
+
+            assertNotNull(response.getRefreshToken());
+
+            System.out.printf("Refresh token: %s%n", response.getRefreshToken());
         });
     }
 
@@ -264,6 +278,143 @@ class AuthControllerTest {
             System.out.printf("Email from token: %s%n", email);
 
             assertEquals(loginRequestDto.getEmail(), email);
+
+            assertNotNull(response.getRefreshToken());
+
+            System.out.printf("Refresh token: %s%n", response.getRefreshToken());
         });
+    }
+
+    @Test
+    public void testRefreshBadRequest() throws Exception {
+        refreshTokenRequestDto.setRefreshToken(null);
+
+        mockMvc.perform(post("/refresh")
+                .accept(MediaType.ALL)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(refreshTokenRequestDto))
+        ).andExpect(
+                status().isBadRequest()
+        ).andDo(result -> {
+            Map<String, Object> response = objectMapper.readValue(
+                    result.getResponse().getContentAsString(),
+                    new TypeReference<>() {
+                    }
+            );
+
+            System.out.printf("response: %s%n", response);
+
+            assertNotNull(response);
+            assertNotNull(response.get("errors"));
+            assertEquals(1, ((Map<?, ?>) response.get("errors")).size());
+            assertEquals("must not be blank", ((Map<?, ?>) response.get("errors")).get("refresh-token"));
+        });
+    }
+
+    @Test
+    public void testRefreshNotFound() throws Exception {
+        refreshTokenRequestDto.setRefreshToken("invalid refresh token");
+
+        mockMvc.perform(post("/refresh")
+                .accept(MediaType.ALL)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(refreshTokenRequestDto))
+        ).andExpect(
+                status().isUnauthorized()
+        ).andDo(result -> {
+            Map<String, Object> response = objectMapper.readValue(
+                    result.getResponse().getContentAsString(),
+                    new TypeReference<>() {
+                    }
+            );
+
+            System.out.printf("response: %s%n", response);
+
+            assertNotNull(response);
+            assertNotNull(response.get("message"));
+            assertEquals("Invalid refresh token", response.get("message"));
+        });
+    }
+
+    @Test
+    public void testRefreshExpired() throws Exception {
+        String rawRefreshToken = SecureRandomUtility.generateRandomString(32);
+        setRefreshToken(rawRefreshToken, Instant.now().minusSeconds(3600));
+        refreshTokenRequestDto.setRefreshToken(rawRefreshToken);
+
+        mockMvc.perform(post("/refresh")
+                .accept(MediaType.ALL)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(refreshTokenRequestDto))
+        ).andExpect(
+                status().isUnauthorized()
+        ).andDo(result -> {
+            Map<String, Object> response = objectMapper.readValue(
+                    result.getResponse().getContentAsString(),
+                    new TypeReference<>() {
+                    }
+            );
+
+            System.out.printf("response: %s%n", response);
+
+            assertNotNull(response);
+            assertNotNull(response.get("message"));
+            assertEquals("Refresh token expired", response.get("message"));
+        });
+    }
+
+    @Test
+    public void testRefreshSuccess() throws Exception {
+        String rawRefreshToken = SecureRandomUtility.generateRandomString(32);
+        setRefreshToken(rawRefreshToken, Instant.now().plusMillis(86400000));
+        refreshTokenRequestDto.setRefreshToken(rawRefreshToken);
+
+        mockMvc.perform(post("/refresh")
+                .accept(MediaType.ALL)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(refreshTokenRequestDto))
+        ).andExpect(
+                status().isOk()
+        ).andDo(result -> {
+            TokenResponseDto response = objectMapper.readValue(
+                    result.getResponse().getContentAsString(),
+                    new TypeReference<>() {}
+            );
+
+            System.out.printf("response: %s%n", response);
+
+            assertNotNull(response);
+
+            assertNotNull(response.getAccessToken());
+
+            String accessToken = response.getAccessToken();
+
+            assertNotNull(jwtUtility.getEmail(accessToken));
+
+            String email = jwtUtility.getEmail(accessToken);
+
+            System.out.printf("Email from token: %s%n", email);
+
+            assertNotNull(response.getRefreshToken());
+
+            System.out.printf("New refresh token: %s%n", response.getRefreshToken());
+        });
+    }
+
+    private void setRefreshToken(String token, Instant expiryDate) {
+        User user = User.builder()
+                .name(USER_NAME)
+                .email(USER_EMAIL)
+                .password(passwordEncoder.encode(USER_PASSWORD))
+                .build();
+
+        RefreshToken refreshToken = RefreshToken.builder()
+                .token(DigestUtils.sha256Hex(token))
+                .expiryDate(expiryDate)
+                .user(user)
+                .build();
+
+        userRepository.save(user);
+        refreshTokenRepository.save(refreshToken);
     }
 }


### PR DESCRIPTION
---

### Summary

This pull request introduces refresh token functionality and its related endpoint (`/refresh`) in the authentication module. It includes changes to generate, validate, and manage refresh tokens for secure token renewal processes, along with improving exception handling and utility support.

### Key Changes

- **Refresh Token Management**:
  - Implement `RefreshToken` entity and `RefreshTokenRepository` for persistence.
  - Add `refreshToken` method in `AuthService` for token renewal and cessation of expired tokens.
  - Extend `TokenResponseDto` to include a `refresh-token` field for enhanced token management.

- **Refresh Token Endpoint**:
  - Add `/refresh` endpoint in the `AuthController` for access token renewal using refresh tokens.
  - Permit public access to the `/refresh` endpoint.

- **DTO Support**:
  - Introduce `RefreshTokenRequestDto` for handling refresh token requests.

- **Testing Enhancements**:
  - Add unit tests to cover refresh token scenarios (success, expiry, and not found cases).
  - Enhance test coverage for `AuthService`, `AuthController`, and related components.

- **Infrastructure and Utilities**:
  - Introduce `UnauthorizedException` and corresponding handling in the `GlobalExceptionHandler`.
  - Add `ValidationUtility` for resolving JSON property names in exception fields.

- **Dependencies and Configurations**:
  - Bump version to `1.1.0-SNAPSHOT` and add `commons-codec` dependency.

### Checklist

- [x] Ensure all tests pass locally and in CI.
- [x] Verify proper validation of refresh token scenarios.
- [x] Confirm endpoint accessibility and security configuration.
- [x] Review and validate new DTO and utility functionality.