### PR TITLE
Add throttling and rate limiting for API requests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>com.krisnaajiep</groupId>
     <artifactId>expense-tracker-api</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0-SNAPSHOT</version>
     <name>expense-tracker-api</name>
     <description>expense-tracker-api</description>
     <url/>
@@ -106,6 +106,13 @@
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
             <version>1.16.0</version>
+        </dependency>
+
+        <!-- For java 17+ -->
+        <dependency>
+            <groupId>com.bucket4j</groupId>
+            <artifactId>bucket4j_jdk17-core</artifactId>
+            <version>8.14.0</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/krisnaajiep/expensetrackerapi/config/FilterConfig.java
+++ b/src/main/java/com/krisnaajiep/expensetrackerapi/config/FilterConfig.java
@@ -11,6 +11,7 @@ Version 1.0
 */
 
 import com.krisnaajiep.expensetrackerapi.filter.RateLimitFilter;
+import com.krisnaajiep.expensetrackerapi.filter.ThrottlingFilter;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -18,9 +19,16 @@ import org.springframework.context.annotation.Configuration;
 @Configuration(proxyBeanMethods = false)
 public class FilterConfig {
     @Bean
+    public FilterRegistrationBean<ThrottlingFilter> registerThrottlingFilter(ThrottlingFilter filter) {
+        FilterRegistrationBean<ThrottlingFilter> registration = new FilterRegistrationBean<>(filter);
+        registration.setOrder(1);
+        return registration;
+    }
+
+    @Bean
     public FilterRegistrationBean<RateLimitFilter> registerRateLimitFilter(RateLimitFilter filter) {
         FilterRegistrationBean<RateLimitFilter> registration = new FilterRegistrationBean<>(filter);
-        registration.setOrder(1);
+        registration.setOrder(2);
         return registration;
     }
 }

--- a/src/main/java/com/krisnaajiep/expensetrackerapi/config/FilterConfig.java
+++ b/src/main/java/com/krisnaajiep/expensetrackerapi/config/FilterConfig.java
@@ -1,0 +1,26 @@
+package com.krisnaajiep.expensetrackerapi.config;
+
+/*
+IntelliJ IDEA 2025.1 (Ultimate Edition)
+Build #IU-251.23774.435, built on April 14, 2025
+@Author krisna a.k.a. Krisna Ajie
+Java Developer
+Created on 07/07/25 08.50
+@Last Modified 07/07/25 08.50
+Version 1.0
+*/
+
+import com.krisnaajiep.expensetrackerapi.filter.RateLimitFilter;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+public class FilterConfig {
+    @Bean
+    public FilterRegistrationBean<RateLimitFilter> registerRateLimitFilter(RateLimitFilter filter) {
+        FilterRegistrationBean<RateLimitFilter> registration = new FilterRegistrationBean<>(filter);
+        registration.setOrder(1);
+        return registration;
+    }
+}

--- a/src/main/java/com/krisnaajiep/expensetrackerapi/config/RateLimitConfig.java
+++ b/src/main/java/com/krisnaajiep/expensetrackerapi/config/RateLimitConfig.java
@@ -1,0 +1,34 @@
+package com.krisnaajiep.expensetrackerapi.config;
+
+/*
+IntelliJ IDEA 2025.1 (Ultimate Edition)
+Build #IU-251.23774.435, built on April 14, 2025
+@Author krisna a.k.a. Krisna Ajie
+Java Developer
+Created on 07/07/25 12.47
+@Last Modified 07/07/25 12.47
+Version 1.0
+*/
+
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+@Component
+@ConfigurationProperties(prefix = "rate-limit")
+@Setter
+@Getter
+@Validated
+public class RateLimitConfig {
+    @Positive
+    private long capacity;
+
+    @Positive
+    private long refillAmount;
+
+    @Positive
+    private long refillDuration;
+}

--- a/src/main/java/com/krisnaajiep/expensetrackerapi/config/ThrottlingConfig.java
+++ b/src/main/java/com/krisnaajiep/expensetrackerapi/config/ThrottlingConfig.java
@@ -1,0 +1,34 @@
+package com.krisnaajiep.expensetrackerapi.config;
+
+/*
+IntelliJ IDEA 2025.1 (Ultimate Edition)
+Build #IU-251.23774.435, built on April 14, 2025
+@Author krisna a.k.a. Krisna Ajie
+Java Developer
+Created on 07/07/25 13.39
+@Last Modified 07/07/25 13.39
+Version 1.0
+*/
+
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+@Component
+@ConfigurationProperties("throttling")
+@Setter
+@Getter
+@Validated
+public class ThrottlingConfig {
+    @Positive
+    private long capacity;
+
+    @Positive
+    private long refillAmount;
+
+    @Positive
+    private long refillDuration;
+}

--- a/src/main/java/com/krisnaajiep/expensetrackerapi/filter/RateLimitFilter.java
+++ b/src/main/java/com/krisnaajiep/expensetrackerapi/filter/RateLimitFilter.java
@@ -1,0 +1,80 @@
+package com.krisnaajiep.expensetrackerapi.filter;
+
+/*
+IntelliJ IDEA 2025.1 (Ultimate Edition)
+Build #IU-251.23774.435, built on April 14, 2025
+@Author krisna a.k.a. Krisna Ajie
+Java Developer
+Created on 06/07/25 22.07
+@Last Modified 06/07/25 22.07
+Version 1.0
+*/
+
+import com.krisnaajiep.expensetrackerapi.config.RateLimitConfig;
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.ConsumptionProbe;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+@Component
+public class RateLimitFilter extends OncePerRequestFilter {
+    private final ConcurrentMap<String, Bucket> buckets = new ConcurrentHashMap<>();
+
+    private final long capacity;
+    private final long refillAmount;
+    private final Duration refillDuration;
+
+    public RateLimitFilter(RateLimitConfig config) {
+        capacity = config.getCapacity();
+        refillAmount = config.getRefillAmount();
+        refillDuration = Duration.ofMillis(config.getRefillDuration());
+    }
+
+    private Bucket createBucket(String clientIp) {
+        Bandwidth bandwidth = Bandwidth.builder()
+                .capacity(capacity)
+                .refillIntervally(refillAmount, refillDuration)
+                .build();
+
+        Bucket bucket = Bucket.builder().addLimit(bandwidth).build();
+
+        return buckets.computeIfAbsent(clientIp, ip -> bucket);
+    }
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain
+    ) throws ServletException, IOException {
+        String clientIp = request.getRemoteAddr();
+        Bucket bucket = createBucket(clientIp);
+
+        ConsumptionProbe probe = bucket.tryConsumeAndReturnRemaining(1);
+        long resetTimestamp = Instant.now().plusNanos(probe.getNanosToWaitForRefill()).getEpochSecond();
+
+        response.setHeader("X-Rate-Limit-Limit", String.valueOf(capacity));
+        response.setHeader("X-Rate-Limit-Remaining", String.valueOf(probe.getRemainingTokens()));
+        response.setHeader("X-Rate-Limit-Reset", String.valueOf(resetTimestamp));
+
+        if (probe.isConsumed()) {
+            filterChain.doFilter(request, response);
+        } else {
+            response.setStatus(429);
+            response.setContentType("application/json");
+            response.getWriter().write("{\"message\": \"Rate limit exceeded\"}");
+        }
+    }
+}

--- a/src/main/java/com/krisnaajiep/expensetrackerapi/filter/ThrottlingFilter.java
+++ b/src/main/java/com/krisnaajiep/expensetrackerapi/filter/ThrottlingFilter.java
@@ -1,0 +1,75 @@
+package com.krisnaajiep.expensetrackerapi.filter;
+
+/*
+IntelliJ IDEA 2025.1 (Ultimate Edition)
+Build #IU-251.23774.435, built on April 14, 2025
+@Author krisna a.k.a. Krisna Ajie
+Java Developer
+Created on 07/07/25 13.12
+@Last Modified 07/07/25 13.12
+Version 1.0
+*/
+
+import com.krisnaajiep.expensetrackerapi.config.ThrottlingConfig;
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.BlockingBucket;
+import io.github.bucket4j.Bucket;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+@Component
+public class ThrottlingFilter extends OncePerRequestFilter {
+    private final ConcurrentMap<String, BlockingBucket> buckets = new ConcurrentHashMap<>();
+
+    private final long capacity;
+    private final long refillAmount;
+    private final Duration refillDuration;
+
+    public ThrottlingFilter(ThrottlingConfig config) {
+        capacity = config.getCapacity();
+        refillAmount = config.getRefillAmount();
+        refillDuration = Duration.ofMillis(config.getRefillDuration());
+    }
+
+    private BlockingBucket createBucket(String clientIp) {
+        Bandwidth bandwidth = Bandwidth.builder()
+                .capacity(capacity)
+                .refillGreedy(refillAmount, refillDuration)
+                .build();
+
+        BlockingBucket bucket = Bucket.builder().addLimit(bandwidth).build().asBlocking();
+
+        return buckets.computeIfAbsent(clientIp, ip -> bucket);
+    }
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain
+    ) throws ServletException, IOException {
+        String clientIp = request.getRemoteAddr();
+        BlockingBucket bucket = createBucket(clientIp);
+
+        try {
+            bucket.consume(1);
+            filterChain.doFilter(request, response);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+
+            response.setStatus(503);
+            response.setContentType("application/json");
+            response.getWriter().write("{\"message\": \"Service unavailable\"}");
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,3 +17,8 @@ spring.jpa.properties.hibernate.default_schema=dbo
 # Jwt Configuration
 jwt.secret=${JWT_SECRET}
 jwt.expiration=3600000
+
+# Rate Limit Configuration
+rate-limit.capacity=10
+rate-limit.refill-amount=1
+rate-limit.refill-duration=1000

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,3 +22,8 @@ jwt.expiration=3600000
 rate-limit.capacity=10
 rate-limit.refill-amount=1
 rate-limit.refill-duration=1000
+
+# Throttling Configuration
+throttling.capacity=1
+throttling.refill-amount=1
+throttling.refill-duration=1000


### PR DESCRIPTION
### Summary

This pull request introduces throttling and rate limiting mechanisms for API requests using the following enhancements:
- **ThrottlingFilter implementation**: Limits API requests per client using the token bucket algorithm with Bucket4j, providing a `503 Service Unavailable` response when limits are exceeded or interruptions occur.
- **RateLimitFilter implementation**: Enforces API rate limits per client and includes rate limit headers in responses.
- **Configuration updates**:
  - Added `throttling` and `rate-limit` property support in `application.properties`.
  - Added `ThrottlingConfig` and `RateLimitConfig` classes for managing settings.
  - Registered filters (`ThrottlingFilter` and `RateLimitFilter`) with appropriate order using `FilterConfig`.
- Updated project dependencies and version:
  - Upgraded version to `1.2.0-SNAPSHOT`.
  - Added `bucket4j_jdk17-core` dependency for Java 17+ compatibility.

### Notes

- Filters leverage `bucket4j` for implementing token bucket-based request control logic.
- Response headers and status codes align with standard API rate-limiting practices.