### PR TITLE
Update refresh token hashing and authentication configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>com.krisnaajiep</groupId>
     <artifactId>expense-tracker-api</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1-SNAPSHOT</version>
     <name>expense-tracker-api</name>
     <description>expense-tracker-api</description>
     <url/>

--- a/src/main/java/com/krisnaajiep/expensetrackerapi/config/AuthConfig.java
+++ b/src/main/java/com/krisnaajiep/expensetrackerapi/config/AuthConfig.java
@@ -10,8 +10,8 @@ Created on 27/06/25 19.08
 Version 1.0
 */
 
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
@@ -20,15 +20,18 @@ import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
 
 @Component
-@ConfigurationProperties(prefix = "jwt")
+@ConfigurationProperties(prefix = "authentication")
 @Setter
 @Getter
 @Validated
-public class JwtConfig {
+public class AuthConfig {
     @NotBlank
     @Size(min = 32, max = 512)
-    private String secret;
+    private String jwtSecret;
 
-    @Min(1)
-    private long expiration;
+    @Positive
+    private long jwtExpiration;
+
+    @Positive
+    private long refreshTokenExpiration;
 }

--- a/src/main/java/com/krisnaajiep/expensetrackerapi/model/RefreshToken.java
+++ b/src/main/java/com/krisnaajiep/expensetrackerapi/model/RefreshToken.java
@@ -36,4 +36,7 @@ public class RefreshToken extends Auditable {
 
     @Column(name = "ExpiryDate", nullable = false)
     private Instant expiryDate;
+
+    @Column(name = "RotatedAt")
+    private Instant rotatedAt;
 }

--- a/src/main/java/com/krisnaajiep/expensetrackerapi/security/JwtUtility.java
+++ b/src/main/java/com/krisnaajiep/expensetrackerapi/security/JwtUtility.java
@@ -10,7 +10,7 @@ Created on 27/06/25 19.06
 Version 1.0
 */
 
-import com.krisnaajiep.expensetrackerapi.config.JwtConfig;
+import com.krisnaajiep.expensetrackerapi.config.AuthConfig;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
@@ -27,9 +27,9 @@ public class JwtUtility {
     private final SecretKey secretKey;
     private final long expiration;
 
-    public JwtUtility(JwtConfig jwtConfig) {
-        this.secretKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(jwtConfig.getSecret()));
-        this.expiration = jwtConfig.getExpiration();
+    public JwtUtility(AuthConfig config) {
+        this.secretKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(config.getJwtSecret()));
+        this.expiration = config.getJwtExpiration();
     }
 
     public String generateToken(String subject, String email) {

--- a/src/main/java/com/krisnaajiep/expensetrackerapi/service/AuthService.java
+++ b/src/main/java/com/krisnaajiep/expensetrackerapi/service/AuthService.java
@@ -150,7 +150,7 @@ public class AuthService {
         String accessToken = jwtUtility.generateToken(user.getId().toString(), user.getEmail());
 
         String newRefreshToken = SecureRandomUtility.generateRandomString(32);
-        refreshToken.setToken(passwordEncoder.encode(newRefreshToken));
+        refreshToken.setToken(DigestUtils.sha256Hex(newRefreshToken));
         refreshToken.setExpiryDate(Instant.now().plusMillis(authConfig.getRefreshTokenExpiration()));
         refreshToken.setRotatedAt(Instant.now());
 

--- a/src/main/java/com/krisnaajiep/expensetrackerapi/service/AuthService.java
+++ b/src/main/java/com/krisnaajiep/expensetrackerapi/service/AuthService.java
@@ -10,6 +10,7 @@ Created on 27/06/25 02.53
 Version 1.0
 */
 
+import com.krisnaajiep.expensetrackerapi.config.AuthConfig;
 import com.krisnaajiep.expensetrackerapi.dto.response.TokenResponseDto;
 import com.krisnaajiep.expensetrackerapi.handler.exception.ConflictException;
 import com.krisnaajiep.expensetrackerapi.handler.exception.UnauthorizedException;
@@ -74,12 +75,7 @@ public class AuthService {
      */
     private final AuthenticationManager authenticationManager;
 
-    /**
-     * A constant representing the expiration time for a refresh token in milliseconds.
-     * This value is used to determine the duration for which a generated refresh token
-     * remains valid before it can no longer be used and must be renewed.
-     */
-    private static final long REFRESH_TOKEN_EXPIRATION_TIME = 86400000; // 24 hours
+    private final AuthConfig authConfig;
 
     /**
      * Registers a new user into the system. If a user with the same email already exists,
@@ -155,7 +151,8 @@ public class AuthService {
 
         String newRefreshToken = SecureRandomUtility.generateRandomString(32);
         refreshToken.setToken(passwordEncoder.encode(newRefreshToken));
-        refreshToken.setExpiryDate(Instant.now().plusMillis(REFRESH_TOKEN_EXPIRATION_TIME));
+        refreshToken.setExpiryDate(Instant.now().plusMillis(authConfig.getRefreshTokenExpiration()));
+        refreshToken.setRotatedAt(Instant.now());
 
         return new TokenResponseDto(accessToken, newRefreshToken);
     }
@@ -173,7 +170,7 @@ public class AuthService {
         return RefreshToken.builder()
                 .user(user)
                 .token(DigestUtils.sha256Hex(token))
-                .expiryDate(Instant.now().plusMillis(REFRESH_TOKEN_EXPIRATION_TIME))
+                .expiryDate(Instant.now().plusMillis(authConfig.getRefreshTokenExpiration()))
                 .build();
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,9 +14,10 @@ spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
 spring.jpa.properties.hibernate.default_schema=dbo
 
-# Jwt Configuration
-jwt.secret=${JWT_SECRET}
-jwt.expiration=3600000
+# Authentication Configuration
+authentication.jwt-secret=${JWT_SECRET}
+authentication.jwt-expiration=3600000
+authentication.refresh-token-expiration=86400000
 
 # Rate Limit Configuration
 rate-limit.capacity=10

--- a/src/test/java/com/krisnaajiep/expensetrackerapi/service/AuthServiceTest.java
+++ b/src/test/java/com/krisnaajiep/expensetrackerapi/service/AuthServiceTest.java
@@ -1,5 +1,6 @@
 package com.krisnaajiep.expensetrackerapi.service;
 
+import com.krisnaajiep.expensetrackerapi.config.AuthConfig;
 import com.krisnaajiep.expensetrackerapi.dto.response.TokenResponseDto;
 import com.krisnaajiep.expensetrackerapi.handler.exception.ConflictException;
 import com.krisnaajiep.expensetrackerapi.handler.exception.UnauthorizedException;
@@ -52,6 +53,9 @@ class AuthServiceTest {
     @Mock
     private CustomUserDetails userDetails;
 
+    @Mock
+    private AuthConfig authConfig;
+
     @InjectMocks
     private AuthService authService;
 
@@ -63,6 +67,7 @@ class AuthServiceTest {
     private static final String ENCODED_REFRESH_TOKEN = DigestUtils.sha256Hex(REFRESH_TOKEN);
     private static final String PASSWORD = SecureRandomUtility.generateRandomString(8);
     private static final String ENCODED_PASSWORD = SecureRandomUtility.generateRandomString(10);
+    private static final long REFRESH_TOKEN_EXP = 86400000;
 
     @BeforeEach
     void setUp() {
@@ -86,6 +91,7 @@ class AuthServiceTest {
         when(passwordEncoder.encode(user.getPassword())).thenReturn(ENCODED_PASSWORD);
         when(userRepository.save(any(User.class))).thenReturn(user);
         when(jwtUtility.generateToken(user.getId().toString(), user.getEmail())).thenReturn(ACCESS_TOKEN);
+        when(authConfig.getRefreshTokenExpiration()).thenReturn(REFRESH_TOKEN_EXP);
 
         TokenResponseDto tokenResponseDto = authService.register(user);
 
@@ -121,6 +127,7 @@ class AuthServiceTest {
         when(userDetails.getId()).thenReturn(user.getId());
         when(userDetails.getUsername()).thenReturn(user.getEmail());
         when(jwtUtility.generateToken(user.getId().toString(), user.getEmail())).thenReturn(ACCESS_TOKEN);
+        when(authConfig.getRefreshTokenExpiration()).thenReturn(REFRESH_TOKEN_EXP);
 
         TokenResponseDto tokenResponseDto = authService.login(user.getEmail(), PASSWORD);
 
@@ -154,6 +161,7 @@ class AuthServiceTest {
     void testRefreshSuccess() {
         when(refreshTokenRepository.findByToken(ENCODED_REFRESH_TOKEN)).thenReturn(Optional.of(refreshToken));
         when(jwtUtility.generateToken(user.getId().toString(), user.getEmail())).thenReturn(ACCESS_TOKEN);
+        when(authConfig.getRefreshTokenExpiration()).thenReturn(REFRESH_TOKEN_EXP);
 
         TokenResponseDto tokenResponseDto = authService.refreshToken(REFRESH_TOKEN);
 


### PR DESCRIPTION
---

### Summary

This pull request fix refresh token hashing error and enhances authentication mechanisms by updating refresh token hashing and making the Authentication configuration more dynamic.

### Changes

- Replaced refresh token password encoding with SHA-256 hashing.
- Made refresh token expiration configurable using `AuthConfig`.
- Deprecated static hardcoded expiration time for refresh tokens.
- Added a `rotatedAt` field to the `RefreshToken` entity for better tracking.
- Refactored `JwtConfig` to `AuthConfig` and updated configuration properties to align with naming conventions.
- Updated the `JwtUtility` class to leverage the dynamic configuration from `AuthConfig`.
- Incremented project version to `1.2.1-SNAPSHOT`.