### PR TITLE
Add refresh token revocation endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>com.krisnaajiep</groupId>
     <artifactId>expense-tracker-api</artifactId>
-    <version>1.2.1</version>
+    <version>1.3.0-SNAPSHOT</version>
     <name>expense-tracker-api</name>
     <description>expense-tracker-api</description>
     <url/>
@@ -48,6 +48,10 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/krisnaajiep/expensetrackerapi/config/SecurityConfig.java
+++ b/src/main/java/com/krisnaajiep/expensetrackerapi/config/SecurityConfig.java
@@ -74,7 +74,12 @@ public class SecurityConfig {
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // Use stateless sessions
                 .httpBasic(AbstractHttpConfigurer::disable) // Disable basic authentication
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/register", "/login", "/refresh").permitAll() // Allow access to the test endpoint
+                        .requestMatchers(
+                                "/register",
+                                "/login",
+                                "/refresh",
+                                "/actuator/health")
+                        .permitAll() // Allow access to the test endpoint
                         .anyRequest().authenticated()) // Require authentication for all other requests
                 .addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .exceptionHandling(exception -> exception

--- a/src/main/java/com/krisnaajiep/expensetrackerapi/controller/AuthController.java
+++ b/src/main/java/com/krisnaajiep/expensetrackerapi/controller/AuthController.java
@@ -16,15 +16,19 @@ import com.krisnaajiep.expensetrackerapi.dto.request.RegisterRequestDto;
 import com.krisnaajiep.expensetrackerapi.dto.response.TokenResponseDto;
 import com.krisnaajiep.expensetrackerapi.mapper.UserMapper;
 import com.krisnaajiep.expensetrackerapi.model.User;
+import com.krisnaajiep.expensetrackerapi.security.CustomUserDetails;
 import com.krisnaajiep.expensetrackerapi.service.AuthService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -65,5 +69,14 @@ public class AuthController {
                 refreshTokenRequestDto.getRefreshToken()
         );
         return ResponseEntity.status(HttpStatus.OK).body(tokenResponseDto);
+    }
+
+    @PostMapping(
+            value = "/revoke",
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public ResponseEntity<Map<String, String>> revoke(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        authService.revoke(userDetails.getId());
+        return ResponseEntity.status(HttpStatus.OK).body(Map.of("message", "All tokens revoked successfully"));
     }
 }

--- a/src/main/java/com/krisnaajiep/expensetrackerapi/service/AuthService.java
+++ b/src/main/java/com/krisnaajiep/expensetrackerapi/service/AuthService.java
@@ -23,6 +23,8 @@ import com.krisnaajiep.expensetrackerapi.security.JwtUtility;
 import com.krisnaajiep.expensetrackerapi.util.SecureRandomUtility;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.codec.digest.DigestUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -43,6 +45,7 @@ import java.time.Instant;
 @RequiredArgsConstructor
 @Transactional
 public class AuthService {
+    private static final Logger log = LoggerFactory.getLogger(AuthService.class);
     /**
      * A repository interface for performing CRUD operations and custom queries on the User entity.
      * This instance is used in the AuthService class to interact with the underlying database to
@@ -155,6 +158,18 @@ public class AuthService {
         refreshToken.setRotatedAt(Instant.now());
 
         return new TokenResponseDto(accessToken, newRefreshToken);
+    }
+
+    /**
+     * Revokes all refresh tokens associated with a specific user by deleting them
+     * from the refresh token repository. This method is typically used during logout
+     * or when the user's access should be invalidated.
+     *
+     * @param userId the unique identifier of the user whose refresh tokens should be revoked
+     */
+    public void revoke(Long userId) {
+        refreshTokenRepository.deleteAllByUserId(userId);
+        log.info("Revoked all refresh tokens for user with id: {}", userId);
     }
 
     /**

--- a/src/test/java/com/krisnaajiep/expensetrackerapi/controller/AuthControllerIT.java
+++ b/src/test/java/com/krisnaajiep/expensetrackerapi/controller/AuthControllerIT.java
@@ -367,6 +367,31 @@ class AuthControllerIT {
         });
     }
 
+    @Test
+    public void testRevokeSuccess() throws Exception {
+        String rawRefreshToken = SecureRandomUtility.generateRandomString(32);
+        setRefreshToken(rawRefreshToken, Instant.now().plusMillis(86400000));
+        refreshTokenRequestDto.setRefreshToken(rawRefreshToken);
+
+        String accessToken = jwtUtility.generateToken(USER_EMAIL, USER_EMAIL);
+
+        mockMvc.perform(post("/revoke")
+                .accept(MediaType.ALL)
+                .header("Authorization", "Bearer " + accessToken)
+        ).andExpect(
+                status().isOk()
+        ).andDo(result -> {
+            Map<String, Object> response = objectMapper.readValue(
+                    result.getResponse().getContentAsString(),
+                    new TypeReference<>() {}
+            );
+
+            assertNotNull(response);
+            assertNotNull(response.get("message"));
+            assertEquals("All tokens revoked successfully", response.get("message"));
+        });
+    }
+
     private void setRefreshToken(String token, Instant expiryDate) {
         User user = User.builder()
                 .name(USER_NAME)


### PR DESCRIPTION
### Summary

- Added a new `/revoke` POST endpoint in `AuthController` to allow revoking all refresh tokens for an authenticated user.
- Implemented the `revoke(Long userId)` method to invalidate user tokens, with appropriate logging using SLF4J.
- Created integration tests (e.g., `testRevokeSuccess`) to verify the functionality and response of the `/revoke` endpoint.
- Enabled unauthenticated access to the `/actuator/health` endpoint by refactoring security configurations.
- Updated project to version `1.3.0-SNAPSHOT` and included a dependency for Spring Boot Actuator for system monitoring.