### PR TITLE
Implement HTTP caching for expense retrieval endpoint

### DIFF
--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,3 +1,0 @@
-# Authentication Properties
-authentication.jwt-expiration=86400000
-authentication.refresh-token-expiration=2592000000

--- a/src/test/java/com/krisnaajiep/expensetrackerapi/controller/ExpenseControllerIT.java
+++ b/src/test/java/com/krisnaajiep/expensetrackerapi/controller/ExpenseControllerIT.java
@@ -12,6 +12,7 @@ import com.krisnaajiep.expensetrackerapi.repository.RefreshTokenRepository;
 import com.krisnaajiep.expensetrackerapi.repository.UserRepository;
 import com.krisnaajiep.expensetrackerapi.security.JwtUtility;
 import com.krisnaajiep.expensetrackerapi.util.SecureRandomUtility;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -457,8 +458,18 @@ class ExpenseControllerIT {
         ).andExpect(
                 status().isOk()
         ).andDo(result -> {
+            String contentAsString = result.getResponse().getContentAsString();
+
+            String actualCacheControl = result.getResponse().getHeader("Cache-Control");
+            String actualEtag = result.getResponse().getHeader("ETag");
+            String expectedCacheControl = "no-cache, must-revalidate, private";
+            String expectedEtag = "\"" + DigestUtils.md5Hex(contentAsString)  + "\"";
+
+            assertEquals(expectedCacheControl, actualCacheControl);
+            assertEquals(expectedEtag, actualEtag);
+
             PagedResponseDto<ExpenseResponseDto> response = objectMapper.readValue(
-                    result.getResponse().getContentAsString(),
+                    contentAsString,
                     new TypeReference<>() {
                     }
             );

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -5,6 +5,3 @@ spring.datasource.driver-class-name=org.h2.Driver
 # JPA Properties
 spring.jpa.hibernate.ddl-auto=create
 spring.jpa.properties.hibernate.default_schema=
-
-# Authentication Properties
-authentication.refresh-token-expiration=3600000


### PR DESCRIPTION
### Summary

This pull request implements the following changes:

- **Expense Retrieval Enhancements**:
    - Added ETag generation using MD5 hash for paged expense responses in the `findAll` endpoint.
    - Implemented `Cache-Control` headers with `no-cache`, `private`, and `must-revalidate` directives for improved caching behavior.
    - Updated the method to handle possible `JsonProcessingException`.

- **Integration Testing**:
    - Verified ETag and `Cache-Control` headers in integration tests for `ExpenseControllerIT`.
    - Used `DigestUtils` MD5 hashing to validate ETag values.

- **Configuration Changes**:
    - Removed authentication properties in development and test profiles to align with current testing needs.

- **Security Improvements**:
    - Enhanced CORS configuration to expose `ETag` and `Retry-After` headers.
    - Strengthened security by disabling form-based authentication in `SecurityConfig`.
    - Introduced Content Security Policy (CSP) headers with strict `default-src 'none'` settings for better protection.